### PR TITLE
Add README with setup and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# RAG-Asker-Tennis
+
+This project provides a retrieval-augmented chatbot for the Asker Tennis Club. It uses Streamlit and a local knowledge base to answer club-related questions about booking, membership and more.
+
+## Environment setup
+
+Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running tests
+
+Execute the test suite to verify the installation:
+
+```bash
+pytest -q
+```
+


### PR DESCRIPTION
## Summary
- Document project purpose for the RAG-Asker-Tennis chatbot
- Add instructions for installing dependencies and running tests

## Testing
- `pytest -q` *(fails: ValueError cannot load pickled data)*

------
https://chatgpt.com/codex/tasks/task_e_68ac02047e38832f8402bdeb2dd2be04